### PR TITLE
Use a 2.8.x version of the Checker Framework

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,9 @@ dependencyManagement {
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'org.checkerframework', name: 'testlib', version: '2.+'
+    testCompile group: 'org.checkerframework', name: 'testlib', version: '2.8.+'
 
-    compile group: 'org.checkerframework', name: 'checker', version: '2.+'
+    compile group: 'org.checkerframework', name: 'checker', version: '2.8.+'
 }
 
 task copyDependencies(type: Copy) {


### PR DESCRIPTION
*Description of changes:*

`@ImplicitFor` was removed in 2.9.0. By depending on a 2.8.x version of the CF compiling the project works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
