### PR TITLE
Don't use deprecated Maven artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencyManagement {
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'org.checkerframework', name: 'testlib', version: '2.8.+'
+    testCompile group: 'org.checkerframework', name: 'framework-test', version: '2.8.+'
 
     compile group: 'org.checkerframework', name: 'checker', version: '2.8.+'
 }


### PR DESCRIPTION
*Description of changes:*
Don't use deprecated Maven artifact

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
